### PR TITLE
Fix compatibility with Symfony Config < 4.2

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -25,10 +25,10 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder('microservice');
+        $treeBuilder = new TreeBuilder();
 
         /** @var ArrayNodeDefinition $rootNode */
-        $rootNode = $treeBuilder->getRootNode();
+        $rootNode = $treeBuilder->root('microservice');
 
         $rootNode
             ->children()
@@ -48,8 +48,7 @@ class Configuration implements ConfigurationInterface
                     ->info('Manage exceptions')
                     ->defaultTrue()
                 ->end()
-            ->end()
-        ;
+            ->end();
 
         $this->addVersionSection($rootNode);
 


### PR DESCRIPTION
The method TreeBuilder::getRootNode is available from Symfony Config 4.2. Any inferior version will crash, fail on unit tests or behave on unexpected ways.